### PR TITLE
Fixed a few minor issues with heroes

### DIFF
--- a/mod/src/includes/heroes/colossus.ttslua
+++ b/mod/src/includes/heroes/colossus.ttslua
@@ -1,6 +1,7 @@
 heroes["colossus"] = {
     name = "Colossus",
     identityCardId = "32001",
+    flipIdentityCard = false,
     hitPoints = 14,
     counterImageUrl = "http://cloud-3.steamusercontent.com/ugc/1753608754708631982/66C54D41798B43098C603591FDEF65D352FC6283/",
     playmatImageUrl = "http://cloud-3.steamusercontent.com/ugc/1796397839017053509/D8746F6183AFEE4C83215A7C8D90257FA717C41E/",

--- a/mod/src/includes/heroes/cyclops.ttslua
+++ b/mod/src/includes/heroes/cyclops.ttslua
@@ -1,6 +1,7 @@
 heroes["cyclops"] = {
     name = "Cyclops",
     identityCardId = "33001",
+    flipIdentityCard = false,
     hitPoints = 10,
     counterImageUrl = "http://cloud-3.steamusercontent.com/ugc/1753608754708633320/40200CC01AB665386C91112894F2253BD850A8CC/",
     playmatImageUrl = "http://cloud-3.steamusercontent.com/ugc/1796397839017049618/A76FB0C2B76F5827D969AD99D316977DA2EA6A26/",

--- a/mod/src/includes/heroes/gambit.ttslua
+++ b/mod/src/includes/heroes/gambit.ttslua
@@ -1,6 +1,7 @@
 heroes["gambit"] = {
     name = "Gambit",
     identityCardId = "37001",
+    flipIdentityCard = false,
     hitPoints = 9,
     counterImageUrl = "http://cloud-3.steamusercontent.com/ugc/1924753791401516991/8BD31B5B7A192AFCAF0D42384304D1801836F7DA/",
     playmatImageUrl = "http://cloud-3.steamusercontent.com/ugc/2035118512673861042/98ECDF1BFE56CC95E1321E96B322ACD211AF5EA1/",

--- a/mod/src/includes/heroes/phoenix.ttslua
+++ b/mod/src/includes/heroes/phoenix.ttslua
@@ -1,6 +1,7 @@
 heroes["phoenix"] = {
     name = "Phoenix",
     identityCardId = "34001",
+    flipIdentityCard = false,
     hitPoints = 9,
     counterImageUrl = "http://cloud-3.steamusercontent.com/ugc/1753608754708633987/0432727CC9279FB95B652C5B9FE9C32374E270B6/",
     playmatImageUrl = "http://cloud-3.steamusercontent.com/ugc/1796397839017046975/35AB82B389228B457C07EB271966C884EF322EB0/",

--- a/mod/src/includes/heroes/rogue.ttslua
+++ b/mod/src/includes/heroes/rogue.ttslua
@@ -1,6 +1,7 @@
 heroes["rogue"] = {
     name = "Rogue",
     identityCardId = "38001",
+    flipIdentityCard = false,
     hitPoints = 11,
     counterImageUrl = "http://cloud-3.steamusercontent.com/ugc/2058745292939695220/25A7C564B51556328CB1987E9F225B51D0C19F69/",
     playmatImageUrl = "http://cloud-3.steamusercontent.com/ugc/2035118512673864953/9F191D57829E59CE767A055C9D3F6D0A08729D0B/",

--- a/mod/src/includes/heroes/shadowcat.ttslua
+++ b/mod/src/includes/heroes/shadowcat.ttslua
@@ -1,6 +1,7 @@
 heroes["shadowCat"] = {
     name = "Shadow Cat",
     identityCardId = "32030",
+    flipIdentityCard = false,
     hitPoints = 9,
     counterImageUrl = "http://cloud-3.steamusercontent.com/ugc/1753608754708630727/F6C8D9E1B2C1EC28EB94559CB6440FF7A1271CD3/",
     playmatImageUrl = "http://cloud-3.steamusercontent.com/ugc/1796397839017055938/24DCF725A8838B827F286B13B623822D8FC6D52A/",

--- a/mod/src/includes/heroes/spectrum.ttslua
+++ b/mod/src/includes/heroes/spectrum.ttslua
@@ -50,6 +50,11 @@ heroes["spectrum"] = {
             rotation = {0, 180, 0},
             locked = false
         }
+    },
+    removeCards = {
+        ["21002"] = "Gamma",
+        ["21003"] = "Photon",
+        ["21004"] = "Pulsar"
     }
 }
 

--- a/mod/src/includes/heroes/spider_woman.ttslua
+++ b/mod/src/includes/heroes/spider_woman.ttslua
@@ -1,6 +1,6 @@
 heroes["spiderWoman"] = {
     name = "Spider-Woman",
-    identityCardId = "04013",
+    identityCardId = "04031",
     hitPoints = 11,
     counterImageUrl = "http://cloud-3.steamusercontent.com/ugc/1833524706209019916/16B45652194597AEF4D441327CBA8E189FB27600/",
     playmatImageUrl = "http://cloud-3.steamusercontent.com/ugc/1861691360008105010/D570286FC250FFA2FB8A69854517ED389DE69222/",

--- a/mod/src/includes/heroes/storm.ttslua
+++ b/mod/src/includes/heroes/storm.ttslua
@@ -1,6 +1,7 @@
 heroes["storm"] = {
     name = "Storm",
     identityCardId = "36001",
+    flipIdentityCard = false,
     hitPoints = 10,
     counterImageUrl = "http://cloud-3.steamusercontent.com/ugc/1924753791401507497/5A35B4B03148F0F73BDDD34B853DA0DEAF0224D4/",
     playmatImageUrl = "http://cloud-3.steamusercontent.com/ugc/2035118512670984888/FE28D2B0688C78A18DACF531F0A27B8BF474A532/",

--- a/mod/src/includes/heroes/wolverine.ttslua
+++ b/mod/src/includes/heroes/wolverine.ttslua
@@ -1,6 +1,7 @@
 heroes["wolverine"] = {
     name = "Wolverine",
     identityCardId = "35001",
+    flipIdentityCard = false,
     hitPoints = 10,
     counterImageUrl = "http://cloud-3.steamusercontent.com/ugc/1738972595193965329/E46BD3229A2F40EB441CCD9BD3EBCAD58567A06D/",
     playmatImageUrl = "http://cloud-3.steamusercontent.com/ugc/2035118512670988007/AAB7036F44B4FADBFFA0D8C904052DA431074F70/",


### PR DESCRIPTION
Addressed these issues:

- Hero identity cards will now consistently be spawned alter-ego side up
- Fixed Spider-Woman's incorrect identity card Id
- Spectrum's three energy form cards are now removed, since our multi-state card makes them redundant